### PR TITLE
Upload content supplier to avoid the same stream to be used.

### DIFF
--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
@@ -106,11 +106,11 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
         break;
       case PUT:
         builder = put(httpSpec.getEndpoint().apply(userSession))
-            .setBody(httpSpec.getUploadContent());
+            .setBody(httpSpec.getUploadContent().get());
         break;
       case POST:
         builder = put(httpSpec.getEndpoint().apply(userSession))
-            .setBody(httpSpec.getUploadContent());
+            .setBody(httpSpec.getUploadContent().get());
         break;
       // case X : rest of methods, we support...
       default:

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpec.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public interface HttpSpec extends Spec {
 
@@ -23,7 +24,7 @@ public interface HttpSpec extends Spec {
   HttpSpec delete();
   HttpSpec patch();
   HttpSpec options();
-  HttpSpec upload(InputStream stream);
+  HttpSpec upload(Supplier<InputStream> stream);
 
   HttpSpec endpoint(String endpoint);
   HttpSpec endpoint(Function<Context, String> endpoint);
@@ -47,7 +48,7 @@ public interface HttpSpec extends Spec {
   // Getters
   Method getMethod();
   Function<Context, String> getEndpoint();
-  InputStream getUploadContent();
+  Supplier<InputStream> getUploadContent();
   List<Function<Context, Entry<String, List<String>>>> getHeaders();
   List<Function<Context, Entry<String, List<String>>>> getQueryParameters();
   boolean isAuth();

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpecImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpecImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Html implementation of {@link Spec}.
@@ -18,7 +19,7 @@ import java.util.function.Function;
  */
 public class HttpSpecImpl extends AbstractSpec implements HttpSpec {
 
-  private InputStream toUpload;
+  private Supplier<InputStream> toUpload;
 
   private List<Function<Context, Entry<String, List<String>>>> headers = new ArrayList<>();
   private List<Function<Context, Entry<String, List<String>>>> queryParams = new ArrayList<>();
@@ -134,13 +135,13 @@ public class HttpSpecImpl extends AbstractSpec implements HttpSpec {
   }
 
   @Override
-  public HttpSpec upload(final InputStream inputStream) {
+  public HttpSpec upload(final Supplier<InputStream> inputStream) {
     this.toUpload = inputStream;
     return this;
   }
 
   @Override
-  public InputStream getUploadContent() {
+  public Supplier<InputStream> getUploadContent() {
     return toUpload;
   }
 


### PR DESCRIPTION
@luxmeter please 

Use supplier to avoid to use the same stream in reactive mode that is causing "stream already closed" exception. 